### PR TITLE
Zero offset

### DIFF
--- a/gedcom_splitter.pyw
+++ b/gedcom_splitter.pyw
@@ -53,5 +53,4 @@ if want_ui:
 else:
     gl.process_ged_file()
     tag.tag_ancestors_families()
-    tag.tag_individuals_families()
     wgf.write_ged_file()

--- a/tag_records.py
+++ b/tag_records.py
@@ -8,12 +8,16 @@ def tag_ancestors_families():
     
     gl.get_params()
     family_id = int(gl.initial_family)
+
+    # Perform ancester walk, mark all families that are ancestrial
     tree_walk(family_id)
 
+    # For all marked ancestrial families, tag individuals in those families (including children)
     for i in gl.families:
         if gl.families[i].tag == 'Y':
             tag_family(gl.families[i].family_id, 0)
 
+    # Tag all descendants of those ancestrial families until no more individuals can be tagged
     additional = 1    
     while additional > 0:
         additional = tag_additional_families()
@@ -22,36 +26,36 @@ def tag_ancestors_families():
     gl.write_families()
 
 def tree_walk(family_id):
-    if family_id > 0:
+    if family_id > -1:
         gl.families[family_id].tag = 'Y'   
-        if gl.families[family_id].husband_id != 0:
+        if gl.families[family_id].husband_id != -1:
             husband_id = gl.families[family_id].husband_id
             family_where_child = gl.get_family_where_child(husband_id)
-            if family_where_child != 0:
+            if family_where_child != -1:
                 tree_walk(family_where_child)
 
-        if gl.families[family_id].wife_id != 0:
+        if gl.families[family_id].wife_id != -1:
             wife_id = gl.families[family_id].wife_id
             family_where_child = gl.get_family_where_child(wife_id)
-            if family_where_child != 0:
+            if family_where_child != -1:
                 tree_walk(family_where_child)
 
 def tag_family(family_id, tag_count):
     husband_id = gl.families[family_id].husband_id
-    if husband_id != 0:
+    if husband_id != -1:
         if gl.individuals[husband_id].tag == "N":
             gl.individuals[husband_id].tag = 'Y'
             tag_count = tag_count + 1
             
     wife_id = gl.families[family_id].wife_id
-    if wife_id != 0:
+    if wife_id != -1:
         if gl.individuals[wife_id].tag == "N":
             gl.individuals[wife_id].tag = 'Y'
             tag_count = tag_count + 1
         
     for i in gl.children:
         child_family_id = gl.children[i].family_id
-        if child_family_id != 0:
+        if child_family_id != -1:
             # removes additional children, we dont want that
             # if child_family_id > family_id: break
             if family_id == child_family_id:

--- a/tag_records.py
+++ b/tag_records.py
@@ -52,7 +52,8 @@ def tag_family(family_id, tag_count):
     for i in gl.children:
         child_family_id = gl.children[i].family_id
         if child_family_id != 0:
-            if child_family_id > family_id: break
+            # removes additional children, we dont want that
+            # if child_family_id > family_id: break
             if family_id == child_family_id:
                 child_id = gl.children[i].child_id
                 if gl.individuals[child_id].tag == "N":


### PR DESCRIPTION
Fixes several bugs including a bug with GEDCOM files produced by some software (here: Gramps) which uses a zero offset for both families and individuals. These files will look like this:

```
0 @I0000@ INDI
1 NAME 
2 GIVN
2 SURN
1 FAMC @F0000@
...
0 @F0000@ FAM
1 HUSB @I0634@
1 WIFE @I0975@
1 MARR
2 DATE 
2 PLAC 
2 ADDR
3 CTRY 
1 CHIL @I0652@
1 CHIL @I0000@
1 CHIL @I0633@
```

- also fixes a bug with an undefined reference to `tag.tag_individuals_families()`
- 953746748a56da2f41aa0a69c1842d9826c1afc7 prevents removal of children if their family ids are higher than current family, leading to loss of children in the tree

requires https://github.com/geoffhunter/gedcom-file-processor/pull/2